### PR TITLE
add netstandard2.0 support

### DIFF
--- a/RxSerialPort/RxSerialPort.csproj
+++ b/RxSerialPort/RxSerialPort.csproj
@@ -1,9 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net7.0;net8.0</TargetFrameworks>
     <RootNamespace>System.IO.Ports</RootNamespace>
 	<Nullable>enable</Nullable>
+	<LangVersion>default</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
add `<LangVersion>default</LangVersion>` to support netstandard2.0 `<Nullable>enable</Nullable>` on my vs2022
https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/configure-language-version

**System.Reactive** doesn't have a dependency on **netstandard2.1**, so I didn't add **netstandard2.1** to **RxSerialPort**